### PR TITLE
Updated driver with fixes

### DIFF
--- a/wsg_50_driver/CMakeLists.txt
+++ b/wsg_50_driver/CMakeLists.txt
@@ -23,7 +23,7 @@ catkin_package(
 
 
 # WSG_50_TCP version
-set(DRIVER_SOURCES 
+set(DRIVER_SOURCES
   src/checksum.cpp include/wsg_50/checksum.h
   src/cmd.c include/wsg_50/cmd.h
   src/common.cpp include/wsg_50/common.h
@@ -66,7 +66,7 @@ endif()
 
 add_executable(wsg_50_ip src/main.cpp ${DRIVER_SOURCES})
 target_link_libraries(wsg_50_ip ${catkin_LIBRARIES})
-add_dependencies(wsg_50_ip wsg_50_common_gencpp)
+add_dependencies(wsg_50_ip wsg_50_common_generate_messages_cpp)
 
 #add_executable(wsg_50_can src/main_can.cpp src/checksum.cpp src/msg.c src/common.cpp src/functions_can.cpp)
 #add_executable(wsg_50_can src/main_can.cpp ${DRIVER_SOURCES_CAN})
@@ -75,5 +75,3 @@ add_dependencies(wsg_50_ip wsg_50_common_gencpp)
 #link_directories(/home/marc/peak-linux-driver-7.5/lib/)
 #add_compile_flags(wsg_50_can -g -Wall)
 #target_link_libraries(wsg_50_can pcan)
-
-

--- a/wsg_50_driver/include/wsg_50/functions.h
+++ b/wsg_50_driver/include/wsg_50/functions.h
@@ -75,6 +75,7 @@ int ack_fault( void );
 
 int setAcceleration( float acc );
 int setGraspingForceLimit( float force );
+int doTare( void );
 
 const char * systemState( void );
 int graspingState( void );

--- a/wsg_50_driver/launch/wsg_50_tcp_script.launch
+++ b/wsg_50_driver/launch/wsg_50_tcp_script.launch
@@ -6,7 +6,7 @@
   <remap from="/joint_states" to="/joint_states_gripper" if="$(arg remap)"/>
 
   <node  name="wsg_50_driver"  pkg="wsg_50_driver" type="wsg_50_ip" output="screen">
-	<param name="ip" type="string" value="192.168.20.2"/>
+	<param name="ip" type="string" value="192.168.0.20"/>
 	<param name="port" type="int" value="1000"/>
     <param name="protocol" type="string" value="tcp"/>
     <param name="com_mode" type="string" value="$(arg com_mode)"/>

--- a/wsg_50_driver/launch/wsg_50_tcp_script.launch
+++ b/wsg_50_driver/launch/wsg_50_tcp_script.launch
@@ -1,5 +1,9 @@
 <launch>
   <arg name="com_mode" default="script" /><!-- or auto_update, polling -->
+  <arg name="remap" default="false" /><!-- Remap joint_states topic. e.g. for joint_state_publisher -->
+  <arg name="force" default="10" />
+
+  <remap from="/joint_states" to="/joint_states_gripper" if="$(arg remap)"/>
 
   <node  name="wsg_50_driver"  pkg="wsg_50_driver" type="wsg_50_ip" output="screen">
 	<param name="ip" type="string" value="192.168.20.2"/>
@@ -7,7 +11,7 @@
     <param name="protocol" type="string" value="tcp"/>
     <param name="com_mode" type="string" value="$(arg com_mode)"/>
     <param name="rate" type="double" value="50"/> <!-- WSG50 HW revision 2: up to 30 Hz with script; 140Hz with auto_update -->
-    <param name="grasping_force" type="double" value="80"/>
+    <param name="grasping_force" type="double" value="$(arg force)"/>
   </node>
 
 </launch>

--- a/wsg_50_driver/launch/wsg_50_udp_script.launch
+++ b/wsg_50_driver/launch/wsg_50_udp_script.launch
@@ -1,14 +1,18 @@
 <launch>
-  <arg name="com_mode" default="script" />
+  <arg name="com_mode" default="script" /><!-- or auto_update, polling -->
+  <arg name="remap" default="false" /><!-- Remap joint_states topic. e.g. for joint_state_publisher -->
+  <arg name="force" default="10" />
 
-  <node  name="wsg_50_driver"  pkg="wsg_50_driver" type="wsg_50_ip" output="screen">
+  <remap from="/joint_states" to="/joint_states_gripper" if="$(arg remap)"/>
+  
+  <node  name="wsg_50_driver"  pkg="wsg_50_driver" type="wsg_50_ip" output="screen" launch-prefix="gdb --args">
 	  <param name="ip" type="string" value="192.168.20.2"/>
 	  <param name="port" type="int" value="1500"/>
 	  <param name="local_port" type="int" value="5501"/>
     <param name="protocol" type="string" value="udp"/>
     <param name="com_mode" type="string" value="$(arg com_mode)"/>
     <param name="rate" type="double" value="50"/>
-    <param name="grasping_force" type="double" value="80"/>
+    <param name="grasping_force" type="double" value="$(arg force)"/>
   </node>
 
 </launch>

--- a/wsg_50_driver/src/common.cpp
+++ b/wsg_50_driver/src/common.cpp
@@ -289,7 +289,7 @@ const char * getStateValues( unsigned char *b ){
 	// D31 ==> MSB
 
 	//dbgPrint("%s\n", resp);
-	return resp;
+	return strdup(resp);
 }
 
 

--- a/wsg_50_driver/src/functions.cpp
+++ b/wsg_50_driver/src/functions.cpp
@@ -469,6 +469,37 @@ int setGraspingForceLimit( float force )
 }
 
 
+int doTare( void )
+{
+    status_t status;
+    int res;
+    unsigned char payload[3];
+    unsigned char *resp;
+    unsigned int resp_len;
+
+    // Submit command and wait for response. Push result to stack.
+    res = cmd_submit( 0x38, payload, 0, true, &resp, &resp_len );
+    if ( res != 2 )
+    {
+        dbgPrint( "Response payload length doesn't match (is %d, expected 2)\n", res );
+        if ( res > 0 ) free( resp );
+        return 0;
+    }
+
+
+    // Check response status
+    status = cmd_get_response_status( resp );
+    free( resp );
+    if ( status != E_SUCCESS )
+    {
+        dbgPrint( "Command TARE not successful: %s\n", status_to_str( status ) );
+        return -1;
+    }
+
+    return 0;
+}
+
+
 ///////////////////
 // GET FUNCTIONS //
 ///////////////////

--- a/wsg_50_driver/src/main.cpp
+++ b/wsg_50_driver/src/main.cpp
@@ -322,9 +322,9 @@ void timer_cb(const ros::TimerEvent& ev)
     // \todo Use name of node for joint names
 	sensor_msgs::JointState joint_states;
 	joint_states.header.stamp = ros::Time::now();;
-	joint_states.header.frame_id = "wsg50_base_link";
-	joint_states.name.push_back("wsg50_finger_left_joint");
-	joint_states.name.push_back("wsg50_finger_right_joint");
+	joint_states.header.frame_id = "summit_xl_wsg50_base_link";
+	joint_states.name.push_back("summit_xl_wsg50_finger_left_joint");
+	joint_states.name.push_back("summit_xl_wsg50_finger_right_joint");
 	joint_states.position.resize(2);
 
 	joint_states.position[0] = -info.position/2000.0;
@@ -335,6 +335,7 @@ void timer_cb(const ros::TimerEvent& ev)
 	joint_states.effort.resize(2);
 	joint_states.effort[0] = info.f_motor;
 	joint_states.effort[1] = info.f_motor;
+	
 
 	g_pub_joint.publish(joint_states);
 
@@ -586,7 +587,7 @@ int main( int argc, char **argv )
 
 		// Publisher
 		g_pub_state = nh.advertise<wsg_50_common::Status>("status", 1000);
-		g_pub_joint = nh.advertise<sensor_msgs::JointState>("/joint_states", 10);
+		g_pub_joint = nh.advertise<sensor_msgs::JointState>("joint_states", 10);
         if (g_mode_script || g_mode_periodic)
             g_pub_moving = nh.advertise<std_msgs::Bool>("moving", 10);
 

--- a/wsg_50_driver/src/main.cpp
+++ b/wsg_50_driver/src/main.cpp
@@ -589,8 +589,10 @@ int main( int argc, char **argv )
         if (g_mode_script || g_mode_periodic)
             g_pub_moving = nh.advertise<std_msgs::Bool>("moving", 10);
 
-		ROS_INFO("Ready to use, homing now...");
+		ROS_INFO("Ready to use. Homing and taring now...");
 		homing();
+        ros::Duration(0.5).sleep();
+        doTare();
 
 		if (grasping_force > 0.0) {
 			ROS_INFO("Setting grasping force limit to %5.1f", grasping_force);

--- a/wsg_50_driver/src/main.cpp
+++ b/wsg_50_driver/src/main.cpp
@@ -319,12 +319,13 @@ void timer_cb(const ros::TimerEvent& ev)
              
 
 	// ==== Joint state msg ====
+    // \todo Use name of node for joint names
 	sensor_msgs::JointState joint_states;
 	joint_states.header.stamp = ros::Time::now();;
-	joint_states.header.frame_id = "wsg_50_gripper_base_link";
-		joint_states.name.push_back("wsg_50_gripper_base_joint_gripper_left");
-	joint_states.name.push_back("wsg_50_gripper_base_joint_gripper_right");
-		joint_states.position.resize(2);
+	joint_states.header.frame_id = "wsg50_base_link";
+	joint_states.name.push_back("wsg50_finger_left_joint");
+	joint_states.name.push_back("wsg50_finger_right_joint");
+	joint_states.position.resize(2);
 
 	joint_states.position[0] = -info.position/2000.0;
 	joint_states.position[1] = info.position/2000.0;
@@ -358,9 +359,9 @@ void read_thread(int interval_ms)
     status_msg.status = "UNKNOWN";
 
     sensor_msgs::JointState joint_states;
-    joint_states.header.frame_id = "wsg_50_gripper_base_link";
-    joint_states.name.push_back("wsg_50_gripper_base_joint_gripper_left");
-    joint_states.name.push_back("wsg_50_gripper_base_joint_gripper_right");
+    joint_states.header.frame_id = "wsg50_base_link";
+    joint_states.name.push_back("wsg50_finger_left_joint");
+    joint_states.name.push_back("wsg50_finger_right_joint");
     joint_states.position.resize(2);
     joint_states.velocity.resize(2);
     joint_states.effort.resize(2);
@@ -381,7 +382,7 @@ void read_thread(int interval_ms)
         msg_free(&msg);
         res = msg_receive( &msg );
         if (res < 0 || msg.len < 2) {
-            ROS_ERROR("Gripper response failure: too short");
+            ROS_ERROR("Gripper response failure");
             continue;
         }
 

--- a/wsg_50_driver/src/main.cpp
+++ b/wsg_50_driver/src/main.cpp
@@ -87,7 +87,7 @@ int g_timer_cnt = 0;
 ros::Publisher g_pub_state, g_pub_joint, g_pub_moving;
 bool g_ismoving = false, g_mode_script = false, g_mode_periodic = false, g_mode_polling = false;
 float g_goal_position = NAN, g_goal_speed = NAN, g_speed = 10.0;
-   
+
 //------------------------------------------------------------------------
 // Unit testing
 //------------------------------------------------------------------------
@@ -143,9 +143,9 @@ bool graspSrv(wsg_50_common::Move::Request &req, wsg_50_common::Move::Response &
 bool incrementSrv(wsg_50_common::Incr::Request &req, wsg_50_common::Incr::Response &res)
 {
 	if (req.direction == "open"){
-	
+
 		if (!objectGraspped){
-		
+
 			float currentWidth = getOpening();
 			float nextWidth = currentWidth + req.increment;
 			if ( (currentWidth < GRIPPER_MAX_OPEN) && nextWidth < GRIPPER_MAX_OPEN ){
@@ -163,12 +163,12 @@ bool incrementSrv(wsg_50_common::Incr::Request &req, wsg_50_common::Incr::Respon
 			objectGraspped = false;
 		}
 	}else if (req.direction == "close"){
-	
+
 		if (!objectGraspped){
 
 			float currentWidth = getOpening();
 			float nextWidth = currentWidth - req.increment;
-		
+
 			if ( (currentWidth > GRIPPER_MIN_OPEN) && nextWidth > GRIPPER_MIN_OPEN ){
 				//grasp(nextWidth, 1);
 				move(nextWidth,20, true);
@@ -277,17 +277,17 @@ void timer_cb(const ros::TimerEvent& ev)
     } else if (g_mode_script) {
 		// ==== Call custom measure-and-move command ====
 		int res = 0;
-		if (!isnan(g_goal_position)) {
+		if (!std::isnan(g_goal_position)) {
 			ROS_INFO("Position command: pos=%5.1f, speed=%5.1f", g_goal_position, g_speed);
             res = script_measure_move(1, g_goal_position, g_speed, info);
-		} else if (!isnan(g_goal_speed)) {
+		} else if (!std::isnan(g_goal_speed)) {
 			ROS_INFO("Velocity command: speed=%5.1f", g_goal_speed);
             res = script_measure_move(2, 0, g_goal_speed, info);
 		} else
             res = script_measure_move(0, 0, 0, info);
-		if (!isnan(g_goal_position))
+		if (!std::isnan(g_goal_position))
 			g_goal_position = NAN;
-		if (!isnan(g_goal_speed))
+		if (!std::isnan(g_goal_speed))
 			g_goal_speed = NAN;
 
 		if (!res) {
@@ -316,7 +316,7 @@ void timer_cb(const ros::TimerEvent& ev)
 	status_msg.force_finger1 = info.f_finger1;
 
 	g_pub_state.publish(status_msg);
-             
+
 
 	// ==== Joint state msg ====
     // \todo Use name of node for joint names
@@ -329,13 +329,13 @@ void timer_cb(const ros::TimerEvent& ev)
 
 	joint_states.position[0] = -info.position/2000.0;
 	joint_states.position[1] = info.position/2000.0;
-	joint_states.velocity.resize(2);		
+	joint_states.velocity.resize(2);
     joint_states.velocity[0] = info.speed/1000.0;
     joint_states.velocity[1] = info.speed/1000.0;
 	joint_states.effort.resize(2);
 	joint_states.effort[0] = info.f_motor;
 	joint_states.effort[1] = info.f_motor;
-	
+
 	g_pub_joint.publish(joint_states);
 
 	// printf("Timer, last duration: %6.1f\n", ev.profile.last_duration.toSec() * 1000.0);
@@ -399,7 +399,7 @@ void read_thread(int interval_ms)
         }
 
         // Handle response types
-        int motion = -1;  
+        int motion = -1;
         switch (msg.id) {
         /*** Opening ***/
         case 0x43:

--- a/wsg_50_driver/src/udp.c
+++ b/wsg_50_driver/src/udp.c
@@ -198,8 +198,11 @@ int udp_read( unsigned char *buf, unsigned int len )
     	// Wait for packet to arrive
     	FD_ZERO( &readfds );
     	FD_SET( conn.sock, &readfds );
-        res = select( conn.sock + 1, &readfds, NULL, NULL, NULL );
-        if ( res < 0 ) return -1;
+        struct timeval timeout;
+        timeout.tv_sec = 0; timeout.tv_usec = 150000;
+        res = select( conn.sock + 1, &readfds, NULL, NULL, &timeout);
+        if ( res == 0 ) return -1; /* timeout */
+        if ( res < 0 ) return -1;  /* error */
 
     	// Get size of packet pending
         res = ioctl( conn.sock, FIONREAD, &packsize );

--- a/wsg_50_simulation/CMakeLists.txt
+++ b/wsg_50_simulation/CMakeLists.txt
@@ -28,8 +28,8 @@ include_directories(
 
 add_executable(wsg_50_sim_keyboard_teleop src/wsg_50_keyboard_teleop.cpp)
 target_link_libraries(wsg_50_sim_keyboard_teleop ${catkin_LIBRARIES})
-add_dependencies(wsg_50_sim_keyboard_teleop wsg_50_common_gencpp)
+add_dependencies(wsg_50_sim_keyboard_teleop wsg_50_common_generate_messages_cpp)
 
 add_executable(wsg_50_sim_driver src/wsg_50_sim_driver.cpp)
 target_link_libraries(wsg_50_sim_driver ${catkin_LIBRARIES})
-add_dependencies(wsg_50_sim_driver wsg_50_common_gencpp)
+add_dependencies(wsg_50_sim_driver wsg_50_common_generate_messages_cpp)

--- a/wsg_50_simulation/urdf/wsg_50.urdf.xacro
+++ b/wsg_50_simulation/urdf/wsg_50.urdf.xacro
@@ -5,7 +5,10 @@
         xmlns:xacro="http://ros.org/wiki/xacro"
 	name="wsg_50">
 
-<xacro:macro name="wsg_50_xacro" params="name parent *origin">
+<!-- finger_length: Length of finger from gripper base. (was 0.023) -->
+<!-- finger_tip:    Offset of finger tip along fingers' motion direction.
+                    Use e.g. for single contact point tip on finger. (default 0) -->
+<xacro:macro name="wsg_50_xacro" params="name parent finger_length finger_tip *origin">
 
  <joint name="${name}_anterior_gripper_joint" type="fixed">
     <insert_block name="origin"/>
@@ -49,9 +52,18 @@
     <turnGravityOff>false</turnGravityOff>
   </gazebo>
 
-  <!-- GRIPPER LEFT -->
+  <joint name="${name}_center_joint" type="fixed">
+     <origin xyz="0 0 ${finger_length}" rpy="0 0 0" />      <!--origin xyz="-0.0067 0 0.049" rpy="0 0 0" /-->
+     <parent link="${name}_base_link"/>
+     <child link="${name}_center" />
+  </joint>
 
-  <joint name="${name}_base_joint_gripper_left" type="prismatic">
+
+  <link name="${name}_center">
+  </link>
+
+  <!-- GRIPPER LEFT -->
+  <joint name="${name}_finger_left_joint" type="prismatic">
      <limit lower="-0.055" upper="-0.0027" effort="1.0" velocity="1.0"/>
      <origin xyz="0 0 0" rpy="0 0 0" />      <!--origin xyz="-0.0067 0 0.049" rpy="0 0 0" /-->
      <parent link="${name}_base_link"/>
@@ -105,9 +117,8 @@
 
 
   <!-- LEFT FINGER -->
-
   <joint name="${name}_guide_joint_finger_left" type="fixed">
-     <origin xyz="0 0 0.023" rpy="0 0 0" />
+     <origin xyz="${finger_tip} 0 ${finger_length}" rpy="0 0 0" />
      <parent link="${name}_gripper_left"/>
      <child link="${name}_finger_left" />
      <dynamics friction="100" damping="100" />
@@ -151,7 +162,7 @@
 
   <!-- GRIPPER RIGHT -->
 
-  <joint name="${name}_base_joint_gripper_right" type="prismatic">
+  <joint name="${name}_finger_right_joint" type="prismatic">
      <limit lower="0.0027" upper="0.055" effort="1.0" velocity="1.0"/>
      <origin xyz="0 0 0" rpy="0 0 3.14159" />
      <parent link="${name}_base_link"/>
@@ -206,7 +217,7 @@
   <!-- RIGHT FINGER -->
 
   <joint name="${name}_guide_joint_finger_right" type="fixed">
-     <origin xyz="0 0 0.023" rpy="0 0 0" />
+     <origin xyz="${finger_tip} 0 ${finger_length}" rpy="0 0 0" />
      <parent link="${name}_gripper_right"/>
      <child link="${name}_finger_right" />
      <dynamics friction="100" damping="100" />


### PR DESCRIPTION
This driver has been configured on a Summit XL and has been updated to prevent an error when returning the device status string on common.cpp that made the driver not publish any information on its topics.

Details on the fixed bug:
In `common.cpp`, the function `getStateValues( unsigned char *b )` was returning null because there was no global memory allocated for the status string.